### PR TITLE
COMPAT: Dask master and sklearn 0.18

### DIFF
--- a/dklearn/tests/test_chained.py
+++ b/dklearn/tests/test_chained.py
@@ -9,7 +9,6 @@ from dask.delayed import Delayed
 from sklearn.base import clone
 from sklearn.datasets import load_iris
 from sklearn.linear_model import LogisticRegression, SGDClassifier
-from toolz import dissoc
 
 import dklearn.matrix as dm
 from dklearn.wrapped import Wrapped
@@ -116,8 +115,8 @@ def test_repr():
     assert res.startswith('Chained')
 
 
-def fit_test(c, X, y):
-    fit = c.fit(X, y)
+def fit_test(c, X, y, **kwargs):
+    fit = c.fit(X, y, **kwargs)
     assert fit is not c
     assert isinstance(fit, Chained)
 
@@ -133,7 +132,7 @@ def test_fit_dask_array():
     y = da.from_array(y_iris, chunks=4)
 
     c = Chained(sgd1)
-    fit_test(c, X, y)
+    fit_test(c, X, y, classes=[0, 1, 2])
 
 
 def test_fit_dask_matrix():
@@ -143,7 +142,7 @@ def test_fit_dask_matrix():
     y = dm.from_bag(y_bag)
 
     c = Chained(sgd1)
-    fit_test(c, X, y)
+    fit_test(c, X, y, classes=[0, 1, 2])
 
 
 def test_predict():
@@ -151,7 +150,7 @@ def test_predict():
     y = da.from_array(y_iris, chunks=4)
 
     c = Chained(sgd1)
-    fit = c.fit(X, y)
+    fit = c.fit(X, y, classes=[0, 1, 2])
 
     pred = fit.predict(X_iris)
     assert isinstance(pred, Delayed)
@@ -173,7 +172,7 @@ def test_score():
     y = da.from_array(y_iris, chunks=4)
 
     c = Chained(sgd1)
-    fit = c.fit(X, y)
+    fit = c.fit(X, y, classes=[0, 1, 2])
 
     s = fit.score(X_iris, y_iris)
     assert isinstance(s, Delayed)

--- a/dklearn/tests/test_cross_validation.py
+++ b/dklearn/tests/test_cross_validation.py
@@ -252,8 +252,8 @@ def test_DaskCVWrapper():
 
 
 def test_check_cv():
-    X = np.arange(9)[:, None]
-    y = np.arange(9)
+    X = np.arange(9)[:, None].repeat(5, 1)
+    y = np.arange(9).repeat(5)
     dX = da.from_array(X, chunks=3)
     dy = da.from_array(y, chunks=3)
 

--- a/dklearn/tests/test_grid_search.py
+++ b/dklearn/tests/test_grid_search.py
@@ -107,7 +107,7 @@ def test_grid_search_dask_inputs_dk_est():
     clf = SGDClassifier()
     d_clf = Chained(SGDClassifier())
     grid_search = GridSearchCV(clf, grid)
-    d_grid_search = GridSearchCV(d_clf, grid)
+    d_grid_search = GridSearchCV(d_clf, grid, fit_params={'classes': [0, 1]})
 
     grid_search.fit(X, y)
     d_grid_search.fit(dX, dy)


### PR DESCRIPTION
I'm assuming that we don't need to worry *too* much about backwards compatibility here, though if we do I can put in a compatibility layer. As it stands, the changes to `dklearn.cross_validation` will mean that `dklearn` requires dask 0.12+ (for the changes in `random_state_data`, cc @jcrist )

There are also a couple changes for scikit-learn 0.18 compatibility. I think these changes should be ok for older versions of scikit-learn.

I'm trying out dklearn today, I'll report back with issues / successes :)