### PR TITLE
Visualize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ python:
     - "3.4"
     - "3.5"
 
+addons:
+    apt:
+        packages:
+        - graphviz
+
 install:
   # Install conda
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
@@ -18,11 +23,12 @@ install:
   - source activate test-environment
   # Scikit-learn requires nose for test functions.
   - conda install dask numpy scikit-learn pytest nose
+  - pip install -q graphviz
   - pip install -q git+https://github.com/dask/dask.git --upgrade
-  - python setup.py develop
+  - pip install --no-deps -e .
 
 script:
-    - py.test dklearn --verbose
+  - py.test dklearn --verbose
 
 notifications:
   email: false

--- a/dklearn/model_selection.py
+++ b/dklearn/model_selection.py
@@ -191,6 +191,31 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
             self.best_estimator_ = best
         return self
 
+    def visualize(self, filename='mydask', format=None, **kwargs):
+        """Render the task graph for this parameter search using ``graphviz``.
+
+        Requires ``graphviz`` to be installed.
+
+        Parameters
+        ----------
+        filename : str or None, optional
+            The name (without an extension) of the file to write to disk.  If
+            `filename` is None, no file will be written, and we communicate
+            with dot using only pipes.
+        format : {'png', 'pdf', 'dot', 'svg', 'jpeg', 'jpg'}, optional
+            Format in which to write output file.  Default is 'png'.
+        **kwargs
+           Additional keyword arguments to forward to ``dask.dot.to_graphviz``.
+
+        Returns
+        -------
+        result : IPython.diplay.Image, IPython.display.SVG, or None
+            See ``dask.dot.dot_graph`` for more information.
+        """
+        check_is_fitted(self, 'dask_graph_')
+        return dask.visualize(self.dask_graph_, filename=filename,
+                              format=format, **kwargs)
+
 
 def _store(results, key_name, array, n_splits, n_candidates,
            weights=None, splits=False, rank=False):

--- a/dklearn/tests/test_model_selection.py
+++ b/dklearn/tests/test_model_selection.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+
+import pytest
+from dask.utils import tmpdir
+from sklearn.datasets import make_classification
+from sklearn.exceptions import NotFittedError
+from sklearn.svm import LinearSVC
+
+from dklearn import DaskGridSearchCV
+
+
+def test_visualize():
+    pytest.importorskip('graphviz')
+
+    X, y = make_classification(n_samples=100, n_classes=2, flip_y=.2,
+                               random_state=0)
+    clf = LinearSVC(random_state=0)
+    grid = {'C': [.1, .5, .9]}
+    gs = DaskGridSearchCV(clf, grid).fit(X, y)
+
+    assert hasattr(gs, 'dask_graph_')
+    assert hasattr(gs, 'dask_keys_')
+
+    with tmpdir() as d:
+        gs.visualize(filename=os.path.join(d, 'mydask'))
+        assert os.path.exists(os.path.join(d, 'mydask.png'))
+
+    # Doesn't work if not fitted
+    gs = DaskGridSearchCV(clf, grid)
+    with pytest.raises(NotFittedError):
+        gs.visualize()

--- a/dklearn/tests/test_model_selection_sklearn.py
+++ b/dklearn/tests/test_model_selection_sklearn.py
@@ -1,4 +1,4 @@
-# NOTE: Most of these tests were copied (with modification) from the equivalent
+# NOTE: These tests were copied (with modification) from the equivalent
 # scikit-learn testing code. The scikit-learn license has been included at
 # dklearn/SCIKIT_LEARN_LICENSE.txt.
 


### PR DESCRIPTION
- Add `visualize` method to the `*SearchCV` objects. This renders the task graph using graphviz
- Move `sklearn` test suite to different file
- Add tests for dask specific functionality
- Add `graphviz` to the `.travis.yml` file