### PR TITLE
Remove `nose` dependency for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,7 @@ install:
   # Install dependencies
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  # Scikit-learn requires nose for test functions.
-  - conda install dask numpy scikit-learn pytest nose
+  - conda install dask numpy scikit-learn pytest
   - pip install -q graphviz
   - pip install --no-deps -e .
 

--- a/dklearn/utils_test.py
+++ b/dklearn/utils_test.py
@@ -1,0 +1,93 @@
+import warnings
+
+import numpy as np
+from sklearn.base import BaseEstimator, ClassifierMixin
+from sklearn.utils.validation import _num_samples, check_array
+
+
+def ignore_warnings(f):
+    """A super simple version of `sklearn.utils.testing.ignore_warnings"""
+    def _(*args, **kwargs):
+        with warnings.catch_warnings(record=True):
+            f(*args, **kwargs)
+    return _
+
+
+# XXX: Mocking classes copied from sklearn.utils.mocking to remove nose
+# dependency.  Can be removed when scikit-learn switches to pytest. See issue
+# here: https://github.com/scikit-learn/scikit-learn/issues/7319
+
+class ArraySlicingWrapper(object):
+    def __init__(self, array):
+        self.array = array
+
+    def __getitem__(self, aslice):
+        return MockDataFrame(self.array[aslice])
+
+
+class MockDataFrame(object):
+    # have shape and length but don't support indexing.
+    def __init__(self, array):
+        self.array = array
+        self.values = array
+        self.shape = array.shape
+        self.ndim = array.ndim
+        # ugly hack to make iloc work.
+        self.iloc = ArraySlicingWrapper(array)
+
+    def __len__(self):
+        return len(self.array)
+
+    def __array__(self, dtype=None):
+        # Pandas data frames also are array-like: we want to make sure that
+        # input validation in cross-validation does not try to call that
+        # method.
+        return self.array
+
+    def __eq__(self, other):
+        return MockDataFrame(self.array == other.array)
+
+
+class CheckingClassifier(BaseEstimator, ClassifierMixin):
+    """Dummy classifier to test pipelining and meta-estimators.
+
+    Checks some property of X and y in fit / predict.
+    This allows testing whether pipelines / cross-validation or metaestimators
+    changed the input.
+    """
+    def __init__(self, check_y=None, check_X=None, foo_param=0,
+                 expected_fit_params=None):
+        self.check_y = check_y
+        self.check_X = check_X
+        self.foo_param = foo_param
+        self.expected_fit_params = expected_fit_params
+
+    def fit(self, X, y, **fit_params):
+        assert len(X) == len(y)
+        if self.check_X is not None:
+            assert self.check_X(X)
+        if self.check_y is not None:
+            assert self.check_y(y)
+        self.classes_ = np.unique(check_array(y, ensure_2d=False,
+                                              allow_nd=True))
+        if self.expected_fit_params:
+            missing = set(self.expected_fit_params) - set(fit_params)
+            assert len(missing) == 0, ('Expected fit parameter(s) %s not '
+                                       'seen.' % list(missing))
+            for key, value in fit_params.items():
+                assert len(value) == len(X), ('Fit parameter %s has length %d; '
+                                              'expected %d.' % (key, len(value),
+                                                                len(X)))
+        return self
+
+    def predict(self, T):
+        if self.check_X is not None:
+            assert self.check_X(T)
+        return self.classes_[np.zeros(_num_samples(T), dtype=np.int)]
+
+    def score(self, X=None, Y=None):
+        if self.foo_param > 1:
+            score = 1.
+        else:
+            score = 0.
+        return score


### PR DESCRIPTION
Scikit-learn currently uses `nose` for tests, while dask projects use
`py.test` (and I like py.test better). Scikit-learn plans to move to
py.test in the near-ish future because `nose` is no longer maintained
(see issue https://github.com/scikit-learn/scikit-learn/issues/7319). As
such, this swaps out the current test/mock stuff that depends on `nose`
to use `py.test` instead.