### PR TITLE
Add a few more missing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: python
 sudo: false
 python:
     - "2.7"
-    - "3.4"
     - "3.5"
+    - "3.6"
 
 addons:
     apt:
@@ -22,11 +22,12 @@ install:
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
   - conda install dask numpy scikit-learn pytest
-  - pip install -q graphviz
+  - pip install -q graphviz flake8
   - pip install --no-deps -e .
 
 script:
   - py.test dklearn --verbose
+  - flake8 dklearn
 
 notifications:
   email: false

--- a/dklearn/tests/test_model_selection.py
+++ b/dklearn/tests/test_model_selection.py
@@ -103,6 +103,10 @@ def test_kfolds(cls, has_shuffle):
         assert (tokenize(cls(shuffle=True, random_state=0)) ==
                 tokenize(cls(shuffle=True, random_state=0)))
 
+        rs = np.random.RandomState(42)
+        assert (tokenize(cls(shuffle=True, random_state=rs)) ==
+                tokenize(cls(shuffle=True, random_state=rs)))
+
         assert (tokenize(cls(shuffle=True, random_state=0)) !=
                 tokenize(cls(shuffle=True, random_state=2)))
 
@@ -380,3 +384,12 @@ def test_pipeline_fit_failure():
         gs.fit(X, y)
 
     check_scores_all_nan(gs, 'bad__parameter')
+
+
+def test_bad_error_score():
+    X, y = make_classification(n_samples=100, n_features=10, random_state=0)
+    gs = DaskGridSearchCV(MockClassifier(), {'foo_param': [0, 1, 2]},
+                          error_score='badparam')
+
+    with pytest.raises(ValueError):
+        gs.fit(X, y)

--- a/dklearn/tests/test_model_selection_sklearn.py
+++ b/dklearn/tests/test_model_selection_sklearn.py
@@ -43,6 +43,7 @@ class LinearSVCNoScore(LinearSVC):
     def score(self):
         raise AttributeError
 
+
 X = np.array([[-1, -1], [-2, -1], [1, 1], [2, 1]])
 y = np.array([1, 1, 2, 2])
 

--- a/dklearn/utils.py
+++ b/dklearn/utils.py
@@ -12,9 +12,7 @@ def _indexable(x):
 
 
 def _maybe_indexable(x):
-    if _is_arraylike(x):
-        return indexable(x)[0]
-    return x
+    return indexable(x)[0] if _is_arraylike(x) else x
 
 
 def to_indexable(*args, **kwargs):

--- a/dklearn/utils_test.py
+++ b/dklearn/utils_test.py
@@ -98,9 +98,6 @@ class MockDataFrame(object):
         # method.
         return self.array
 
-    def __eq__(self, other):
-        return MockDataFrame(self.array == other.array)
-
 
 class CheckingClassifier(BaseEstimator, ClassifierMixin):
     """Dummy classifier to test pipelining and meta-estimators.


### PR DESCRIPTION
- Test hashing of explicit random state in CV objects
- Test failure when bad `error_score` provided
- Remove some unneeded lines
- Add flake8 to travis testing
- Add python 3.6 to matrix, remove python 3.4

Now at 99% test coverage.