### PR TITLE
ignores extra parameters that are not implemented, like n_jobs

### DIFF
--- a/dklearn/model_selection.py
+++ b/dklearn/model_selection.py
@@ -182,7 +182,7 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
 class DaskGridSearchCV(DaskBaseSearchCV):
     def __init__(self, estimator, param_grid, scoring=None, iid=True,
                  refit=True, cv=None, error_score='raise',
-                 return_train_score=True, get=None):
+                 return_train_score=True, get=None, *args, **kwargs):
         super(DaskGridSearchCV, self).__init__(estimator=estimator,
                 scoring=scoring, iid=iid, refit=refit, cv=cv,
                 error_score=error_score, return_train_score=return_train_score,
@@ -199,7 +199,8 @@ class DaskGridSearchCV(DaskBaseSearchCV):
 class DaskRandomizedSearchCV(DaskBaseSearchCV):
     def __init__(self, estimator, param_distributions, n_iter=10, scoring=None,
                  iid=True, refit=True, cv=None, random_state=None,
-                 error_score='raise', return_train_score=True, get=None):
+                 error_score='raise', return_train_score=True, get=None,
+                 *args, **kwargs):
         super(DaskRandomizedSearchCV, self).__init__(estimator=estimator,
                 scoring=scoring, iid=iid, refit=refit, cv=cv,
                 error_score=error_score, return_train_score=return_train_score,


### PR DESCRIPTION
Ignoring n_jobs helps with compatibility while porting code from sklearn to dask-learn