### PR TITLE
More optimizations

### DIFF
--- a/dklearn/core.py
+++ b/dklearn/core.py
@@ -22,9 +22,10 @@ from sklearn.model_selection._split import (_BaseKFold,
 from sklearn.pipeline import Pipeline
 from sklearn.utils.multiclass import type_of_target
 
-from .methods import (fit, fit_transform, pipeline, fit_best, get_best_params,
-                      create_cv_results, cv_split, cv_n_samples, cv_extract,
-                      cv_extract_params, decompress_params, score, MISSING)
+from .methods import (fit, fit_transform, fit_and_score, pipeline, fit_best,
+                      get_best_params, create_cv_results, cv_split,
+                      cv_n_samples, cv_extract, cv_extract_params,
+                      decompress_params, score, MISSING)
 from ._normalize import normalize_estimator
 
 from .utils import to_indexable, to_keys, unzip
@@ -84,36 +85,10 @@ def build_graph(estimator, cv, scorer, candidate_params, X, y=None,
     else:
         weights = None
 
-    X_train = (cv_extract, cv_name, X_name, y_name, True, True)
-    X_test = (cv_extract, cv_name, X_name, y_name, True, False)
-    y_train = (cv_extract, cv_name, X_name, y_name, False, True)
-    y_test = (cv_extract, cv_name, X_name, y_name, False, False)
-
-    # Fit the estimator on the training data
-    X_trains = [X_train] * len(params)
-    y_trains = [y_train] * len(params)
-    fit_ests = do_fit(dsk, TokenIterator(main_token), estimator, cv_name,
-                      fields, tokens, params, X_trains, y_trains,
-                      fit_params, n_splits, error_score)
-
-    score_name = 'score-' + main_token
-
-    scores = []
-    scores_append = scores.append
-    for n in range(n_splits):
-        if return_train_score:
-            xtrain = X_train + (n,)
-            ytrain = y_train + (n,)
-        else:
-            xtrain = ytrain = None
-
-        xtest = X_test + (n,)
-        ytest = y_test + (n,)
-
-        for (name, m) in fit_ests:
-            dsk[(score_name, m, n)] = (score, (name, m, n),
-                                       xtest, ytest, xtrain, ytrain, scorer)
-            scores_append((score_name, m, n))
+    scores = do_fit_and_score(dsk, main_token, estimator, cv_name, fields,
+                              tokens, params, X_name, y_name, fit_params,
+                              n_splits, error_score, scorer,
+                              return_train_score)
 
     cv_results = 'cv-results-' + main_token
     candidate_params_name = 'cv-parameters-' + main_token
@@ -170,6 +145,70 @@ def _group_fit_params(steps, fit_params):
         step, param = pname.split('__', 1)
         param_lk[step][param] = pval
     return param_lk
+
+
+def do_fit_and_score(dsk, main_token, est, cv, fields, tokens, params,
+                     X, y, fit_params, n_splits, error_score, scorer,
+                     return_train_score):
+    if not isinstance(est, Pipeline):
+        # Fitting and scoring can all be done as a single task
+        n_and_fit_params = _get_fit_params(cv, fit_params, n_splits)
+
+        est_type = type(est).__name__.lower()
+        est_name = '%s-%s' % (est_type, main_token)
+        score_name = '%s-fit-score-%s' % (est_type, main_token)
+        dsk[est_name] = est
+
+        seen = {}
+        m = 0
+        out = []
+        out_append = out.append
+
+        for t, p in zip(tokens, params):
+            if t in seen:
+                out_append(seen[t])
+            else:
+                for n, fit_params in n_and_fit_params:
+                    dsk[(score_name, m, n)] = (fit_and_score, est_name, cv,
+                                               X, y, n, scorer, error_score,
+                                               fields, p, fit_params,
+                                               return_train_score)
+                seen[t] = (score_name, m)
+                out_append((score_name, m))
+                m += 1
+        scores = [k + (n,) for n in range(n_splits) for k in out]
+    else:
+        X_train = (cv_extract, cv, X, y, True, True)
+        X_test = (cv_extract, cv, X, y, True, False)
+        y_train = (cv_extract, cv, X, y, False, True)
+        y_test = (cv_extract, cv, X, y, False, False)
+
+        # Fit the estimator on the training data
+        X_trains = [X_train] * len(params)
+        y_trains = [y_train] * len(params)
+        fit_ests = do_fit(dsk, TokenIterator(main_token), est, cv,
+                          fields, tokens, params, X_trains, y_trains,
+                          fit_params, n_splits, error_score)
+
+        score_name = 'score-' + main_token
+
+        scores = []
+        scores_append = scores.append
+        for n in range(n_splits):
+            if return_train_score:
+                xtrain = X_train + (n,)
+                ytrain = y_train + (n,)
+            else:
+                xtrain = ytrain = None
+
+            xtest = X_test + (n,)
+            ytest = y_test + (n,)
+
+            for (name, m) in fit_ests:
+                dsk[(score_name, m, n)] = (score, (name, m, n),
+                                        xtest, ytest, xtrain, ytrain, scorer)
+                scores_append((score_name, m, n))
+    return scores
 
 
 def do_fit(dsk, next_token, est, cv, fields, tokens, params, Xs, ys,

--- a/dklearn/methods.py
+++ b/dklearn/methods.py
@@ -125,6 +125,11 @@ def cv_extract_params(cvs, keys, vals, n):
     return {k: cvs.extract_param(tok, v, n) for (k, tok), v in zip(keys, vals)}
 
 
+def decompress_params(fields, params):
+    return [{k: v for k, v in zip(fields, p) if v is not MISSING}
+            for p in params]
+
+
 def pipeline(names, steps):
     """Reconstruct a Pipeline from names and steps"""
     if any(s is FIT_FAILURE for s in steps):

--- a/dklearn/methods.py
+++ b/dklearn/methods.py
@@ -227,6 +227,19 @@ def score(est, X_test, y_test, X_train, y_train, scorer):
     return test_score, train_score
 
 
+def fit_and_score(est, cv, X, y, n, scorer,
+                  error_score='raise', fields=None, params=None,
+                  fit_params=None, return_train_score=True):
+    X_train = cv.extract(X, y, n, True, True)
+    y_train = cv.extract(X, y, n, False, True)
+    X_test = cv.extract(X, y, n, True, False)
+    y_test = cv.extract(X, y, n, False, False)
+    est = fit(est, X_train, y_train, error_score, fields, params, fit_params)
+    if not return_train_score:
+        X_train = y_train = None
+    return score(est, X_test, y_test, X_train, y_train, scorer)
+
+
 def _store(results, key_name, array, n_splits, n_candidates,
            weights=None, splits=False, rank=False):
     """A small helper to store the scores/times to the cv_results_"""

--- a/dklearn/tests/test_model_selection.py
+++ b/dklearn/tests/test_model_selection.py
@@ -471,7 +471,7 @@ def test_cache_cv():
     gs = DaskGridSearchCV(MockClassifier(), {'foo_param': [0, 1, 2]},
                           cv=3, cache_cv=False, get=dask.get)
     gs.fit(X2, y)
-    assert X2.count == 3 * 3 * 3  # (2 train + 1 test) for n_params * n_splits
+    assert X2.count == 2 * 3 * 3  # (1 train + 1 test) * n_params * n_splits
 
     X2 = X.view(CountTakes)
     assert X2.count == 0


### PR DESCRIPTION
This adds a few optimizations to reduce the overhead of graph building and serialization:

-  Send parameters to scheduler in a compressed form

Instead of sending parameters as a list of dicts, each with the same keys, we send the keys and a list of tuples. This reduces the serialized size of the parameters by ~50%.

- Reduce graph size for basic estimators

Previously every cv_split + param combo had at least 2 tasks: one to fit and one to score. For the common case of non-pipelines, we can combine these into a single task, reducing the graph size by 50%.

Using the following benchmark:

```python
import numpy as np
from sklearn.tree import DecisionTreeClassifier
from dklearn import DaskGridSearchCV
from sklearn.datasets import make_classification
from timeit import default_timer
import pickle

# Make data small so nbytes cost is negligible
X, y = make_classification(2, n_features=5)

model = DecisionTreeClassifier()
# 500,000 samples
grid = {'max_depth': np.arange(1, 1001),      # 1000
        'random_state': np.arange(100),       # 100
        'min_samples_leaf': np.arange(1, 6)}  # 5

grid_search = DaskGridSearchCV(model, grid)
start = default_timer()
grid_search.fit(X, y)
stop = default_timer()
print("Graph building took %.3f seconds" % (stop - start))
print("Graph has %d tasks" % len(grid_search.dask_graph_))
start = default_timer()
nbytes = sum(len(pickle.dumps(v, 4)) for v in grid_search.dask_graph_.values())
stop = default_timer()
print("Serialized graph takes %.3f GB" % (nbytes / 1e9))
print("Serializing graph took %.3f seconds" % (stop - start))
```

Master:

```
(dask) jcrist grid-search $ python dklearn_grid_search_script.py
Graph building took 14.465 seconds
Graph has 3000008 tasks
Serialized graph takes 1.403 GB
Serializing graph took 42.132 seconds
```

This PR:

```
(dask) jcrist grid-search $ python dklearn_grid_search_script.py
Graph building took 10.092 seconds
Graph has 1500009 tasks
Serialized graph takes 0.761 GB
Serializing graph took 31.358 seconds
```